### PR TITLE
Add GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,16 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Install dependencies and commitizen
-        run: uv pip install commitizen
+        run: uv pip install commitizen --system
 
       - name: Get changelog
         id: changelog
         run: |
-          echo "changelog=$(cz changelog --dry-run)" >> $GITHUB_OUTPUT
+          {
+            echo 'changelog<<EOF'
+            cz changelog --dry-run
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build package
         run: uv build
@@ -45,4 +49,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to PyPI
-        run: uv publish --with-token ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish --token ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ onedriveuploader = "onedriveuploader.main:main"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-tag_format = "$version"
+tag_format = "v$version"
 version_scheme = "semver2"
 version_provider = "uv"
 update_changelog_on_bump = true


### PR DESCRIPTION
This pull request includes updates to the release workflow and project configuration files to improve compatibility and standardization. The most important changes involve modifications to the `release.yml` workflow and adjustments to the `pyproject.toml` configuration.

### Workflow updates in `.github/workflows/release.yml`:

* Changed the `pip install` command to include the `--system` flag for better compatibility in the release workflow.
* Updated the changelog generation process to use a more robust syntax for appending the changelog output to `$GITHUB_OUTPUT`.
* Simplified the PyPI publish command by replacing `--with-token` with `--token` for clarity and alignment with tool conventions.

### Configuration updates in `pyproject.toml`:

* Updated the `tag_format` in the Commitizen tool configuration to prepend a "v" to the version number, aligning with semantic versioning practices.